### PR TITLE
[GSK-2287] Wrap HF inference api with giskard model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
     parser.add_argument("--scan_config", help="Path to YAML file containing the configuration of the scan.")
     parser.add_argument("--output", help="Optional name of the output file.")
     parser.add_argument("--output_format", help="Format of the report (either HTML or markdown). Default is HTML.")
+    parser.add_argument("--hf_token", help="Give your hugging face token to use inference api.")
 
     args = parser.parse_args()
 
@@ -38,7 +39,8 @@ if __name__ == "__main__":
 
     if args.loader == "huggingface":
         runner_kwargs.update({"dataset_split": args.dataset_split,
-                              "dataset_config": args.dataset_config})
+                              "dataset_config": args.dataset_config,
+                              "hf_token": args.hf_token})
 
     report = runner.run(**runner_kwargs)
 
@@ -53,4 +55,5 @@ if __name__ == "__main__":
             f.write(rendered_report)
     else:
         # To stdout
-        print(rendered_report)
+        # print(rendered_report)
+        report.scan_result.print()

--- a/cli.py
+++ b/cli.py
@@ -55,5 +55,4 @@ if __name__ == "__main__":
             f.write(rendered_report)
     else:
         # To stdout
-        # print(rendered_report)
-        report.scan_result.print()
+        print(rendered_report)

--- a/giskard_cicd/loaders/huggingface_inf_model.py
+++ b/giskard_cicd/loaders/huggingface_inf_model.py
@@ -23,7 +23,7 @@ def extract_scores(data):
     
     return scores
 
-def predict_from_inference(df: pd.DataFrame, query) -> np.ndarray:
+def predict_from_text_classification_inference(df: pd.DataFrame, query) -> np.ndarray:
     results = []
     # get all text from the dataframe
     inputs = df["text"].tolist()
@@ -37,10 +37,19 @@ def predict_from_inference(df: pd.DataFrame, query) -> np.ndarray:
 
     return np.array(results)
 
-def classification_model_from_inference_api(model_name, labels, features, query):
+def classification_model_from_inference_api(model_name, labels, features, query, model_type="text_classification"):
     """Get a Giskard model from the HuggingFace inference API."""
+    if model_type == "text_classification":
+        def prediction(df: pd.DataFrame) -> np.ndarray:
+            return predict_from_text_classification_inference(df, query)
+    else:
+        raise NotImplementedError("Only text_classification models are supported for now.")
+    
+    if prediction is None:
+        raise ValueError("The prediction function is None. Please check your model name and the inference API.")
+    
     return Model(
-        model = lambda df: predict_from_inference(df, query),  # A prediction function that encapsulates all the data pre-processing steps and that
+        model = prediction,  # A prediction function that encapsulates all the data pre-processing steps and that
         model_type="classification",  # Either regression, classification or text_generation.
         name=model_name,  # Optional
         classification_labels=labels,  # Their order MUST be identical to the prediction_function's

--- a/giskard_cicd/loaders/huggingface_inf_model.py
+++ b/giskard_cicd/loaders/huggingface_inf_model.py
@@ -1,0 +1,49 @@
+from giskard import Model
+import pandas as pd
+import numpy as np
+from time import sleep
+
+def extract_scores(data):
+    scores = []
+    
+    if isinstance(data, dict):
+        # extract 'score' value if it exists
+        score = data.get('score')
+        if score is not None:
+            scores.append(score)
+        
+        # Recursively process dictionary values
+        for value in data.values():
+            scores.extend(extract_scores(value))
+    
+    elif isinstance(data, list):
+        # recursively process list elements
+        for element in data:
+            scores.extend(extract_scores(element))
+    
+    return scores
+
+def predict_from_inference(df: pd.DataFrame, query) -> np.ndarray:
+    results = []
+    # get all text from the dataframe
+    inputs = df["text"].tolist()
+
+    payload = {"inputs": inputs, "options": {"use_cache": True, "wait_for_model": True}}
+    output = query(payload)
+    sleep(0.5)
+
+    for i in output:
+        results.append(extract_scores(i))
+
+    return np.array(results)
+
+def classification_model_from_inference_api(model_name, labels, features, query):
+    """Get a Giskard model from the HuggingFace inference API."""
+    return Model(
+        model = lambda df: predict_from_inference(df, query),  # A prediction function that encapsulates all the data pre-processing steps and that
+        model_type="classification",  # Either regression, classification or text_generation.
+        name=model_name,  # Optional
+        classification_labels=labels,  # Their order MUST be identical to the prediction_function's
+        feature_names=features  # Default: all columns of your dataset
+    )
+

--- a/giskard_cicd/loaders/huggingface_loader.py
+++ b/giskard_cicd/loaders/huggingface_loader.py
@@ -65,7 +65,7 @@ class HuggingFaceLoader(BaseLoader):
         hf_model = self.load_model(model)
 
         # Check that the dataset has the good feature names for the task.
-        if manual_feature_mapping is not None:
+        if manual_feature_mapping is None:
             feature_mapping = self._get_feature_mapping(hf_model, hf_dataset)
         else:
             feature_mapping = manual_feature_mapping

--- a/giskard_cicd/pipeline/runner.py
+++ b/giskard_cicd/pipeline/runner.py
@@ -1,6 +1,7 @@
 import yaml
 import giskard as gsk
 
+
 class PipelineReport:
     def __init__(self, scan_result):
         self.scan_result = scan_result
@@ -32,9 +33,10 @@ class PipelineRunner:
 
         # Load the model and dataset
         gsk_model, gsk_dataset = loader.load_giskard_model_dataset(**kwargs)
-        
+
         # Run the scanner
         scan_result = gsk.scan(gsk_model, gsk_dataset, params=params, only=detectors)
+
         # Report
         report = PipelineReport(scan_result)
 

--- a/giskard_cicd/pipeline/runner.py
+++ b/giskard_cicd/pipeline/runner.py
@@ -1,6 +1,6 @@
 import yaml
 import giskard as gsk
-
+import time
 
 class PipelineReport:
     def __init__(self, scan_result):
@@ -32,11 +32,14 @@ class PipelineRunner:
             detectors = list(scan_config.get("detectors", None))
 
         # Load the model and dataset
+        start = time.time()
         gsk_model, gsk_dataset = loader.load_giskard_model_dataset(**kwargs)
-
+        print(f"Loading took {time.time() - start} seconds.")
+        
+        start = time.time()
         # Run the scanner
         scan_result = gsk.scan(gsk_model, gsk_dataset, params=params, only=detectors)
-
+        print(f"Scan took {time.time() - start} seconds.")
         # Report
         report = PipelineReport(scan_result)
 

--- a/giskard_cicd/pipeline/runner.py
+++ b/giskard_cicd/pipeline/runner.py
@@ -1,6 +1,5 @@
 import yaml
 import giskard as gsk
-import time
 
 class PipelineReport:
     def __init__(self, scan_result):
@@ -32,14 +31,10 @@ class PipelineRunner:
             detectors = list(scan_config.get("detectors", None))
 
         # Load the model and dataset
-        start = time.time()
         gsk_model, gsk_dataset = loader.load_giskard_model_dataset(**kwargs)
-        print(f"Loading took {time.time() - start} seconds.")
         
-        start = time.time()
         # Run the scanner
         scan_result = gsk.scan(gsk_model, gsk_dataset, params=params, only=detectors)
-        print(f"Scan took {time.time() - start} seconds.")
         # Report
         report = PipelineReport(scan_result)
 

--- a/giskard_cicd/pipeline/scan_config.yaml
+++ b/giskard_cicd/pipeline/scan_config.yaml
@@ -1,0 +1,13 @@
+detectors:
+  - ethical_bias
+  - text_perturbation
+  - robustness
+  - performance
+  - underconfidence
+  - overconfidence
+  - spurious_correlation
+
+configuration:
+  ethical_bias:
+    threshold:
+      0.01

--- a/readme.md
+++ b/readme.md
@@ -91,4 +91,8 @@ Current implementation has two loaders:
   $ python cli.py --loader huggingface --model distilbert-base-uncased-finetuned-sst-2-english --dataset_split validation --output demo_report.html
   ```
 
+  ```bash
+  $   python cli.py --loader huggingface --model distilbert-base-uncased-finetuned-sst-2-english --dataset_split validation --scan_config [Path to scan_config.yaml] --hf_token [Huggingface Token]
+  ```
+
 This will launch a pipeline that will load the model and dataset from the HuggingFace hub, run the scan and generate a report in HTML format (for now).


### PR DESCRIPTION
First experiments show that there could be OOM on our VPS, and it's slow.

Try to wrap Hf inference API to run the prediction, and see the limits.

Solution:
Wrapped inference api as model prediction function and sleep for 500ms after every call to avoid rate limit.

What we know for now:
- With some sleep time and batch sending the data to query we are fine with the rate limit.
- no sleep time will result in rate limit before the second detector
- single slicing requests (ie. data leakage) could incur a lot of sleeping time