### PR TITLE
[GSK-2526] Remove user hugging face token from config files

### DIFF
--- a/giskard_cicd/cli.py
+++ b/giskard_cicd/cli.py
@@ -66,6 +66,13 @@ def main():
     parser.add_argument(
         "--leaderboard_dataset", help="The leaderboard dataset to push the report to."
     )
+    parser.add_argument(
+        "--inference_type",
+        help="The inference type to use. Default is `hf_inference_api`.",
+    )
+    parser.add_argument(
+        "--inference_api_token", help="The HF token to call inference API with."
+    )
 
     # Giskard hub upload args, set --giskard_hub_api_key to upload
     parser.add_argument(
@@ -128,6 +135,8 @@ def main():
                 "dataset_split": args.dataset_split,
                 "dataset_config": args.dataset_config,
                 "hf_token": args.hf_token,
+                "inference_type": args.inference_type,
+                "inference_api_token": args.inference_api_token,
             }
         )
         try:

--- a/giskard_cicd/loaders/huggingface_inf_model.py
+++ b/giskard_cicd/loaders/huggingface_inf_model.py
@@ -32,7 +32,7 @@ def predict_from_text_classification_inference(df: pd.DataFrame, query) -> np.nd
 
     payload = {"inputs": inputs, "options": {"use_cache": True, "wait_for_model": True}}
     output = query(payload)
-    sleep(5)
+    sleep(0.5)
 
     for i in output:
         results.append(extract_scores(i))

--- a/giskard_cicd/loaders/huggingface_inf_model.py
+++ b/giskard_cicd/loaders/huggingface_inf_model.py
@@ -32,7 +32,7 @@ def predict_from_text_classification_inference(df: pd.DataFrame, query) -> np.nd
 
     payload = {"inputs": inputs, "options": {"use_cache": True, "wait_for_model": True}}
     output = query(payload)
-    sleep(0.5)
+    sleep(5)
 
     for i in output:
         results.append(extract_scores(i))

--- a/giskard_cicd/loaders/huggingface_loader.py
+++ b/giskard_cicd/loaders/huggingface_loader.py
@@ -47,7 +47,7 @@ class HuggingFaceLoader(BaseLoader):
         classification_label_mapping: Dict[int, str] = None,
         hf_token=None,
         inference_type="hf_pipeline",
-        inference_token=None,
+        inference_api_token=None,
     ):
         # If no dataset was provided, we try to get it from the model metadata.
         if dataset is None:
@@ -128,7 +128,7 @@ class HuggingFaceLoader(BaseLoader):
             features=feature_mapping,
             inference_type=inference_type,
             device=self.device,
-            hf_token=inference_token,
+            hf_token=inference_api_token,
         )
 
         # Optimize batch size

--- a/giskard_cicd/pipeline/runner.py
+++ b/giskard_cicd/pipeline/runner.py
@@ -36,9 +36,6 @@ class PipelineRunner:
 
             params = scan_config.get("configuration")
             detectors = scan_config.get("detectors")
-            kwargs.update({"inference_type": scan_config.get("inference_type", "hf_inference_api")})
-            kwargs.update({"inference_token": scan_config.get("inference_token")})
-
 
         start = time.time()
         # Load the model and dataset


### PR DESCRIPTION
Pass the token arg in cicd command because (by design) everyone will be able to access config files in the Hugging Face Spaces.

Additional fix:
- Moved the inference type arg in command as it is related to this inference token. 

Testing:
- Manually run locally with command