### PR TITLE
[GSK-2572] Remove HF token

### DIFF
--- a/giskard_cicd/loaders/huggingface_inf_model.py
+++ b/giskard_cicd/loaders/huggingface_inf_model.py
@@ -1,91 +1,105 @@
 import logging
+import os
 from time import sleep
 
 import numpy as np
 import pandas as pd
+import requests
 from giskard import Model
 
 logger = logging.getLogger(__file__)
-
-
-def extract_scores(data):
-    scores = []
-
-    if isinstance(data, dict):
-        # extract 'score' value if it exists
-        score = data.get("score")
-        if score is not None:
-            scores.append(score)
-
-        # Recursively process dictionary values
-        for value in data.values():
-            scores.extend(extract_scores(value))
-
-    elif isinstance(data, list):
-        # recursively process list elements
-        for element in data:
-            scores.extend(extract_scores(element))
-
-    return scores
-
-
-def predict_from_text_classification_inference(
-    df: pd.DataFrame, query, inference_api_batch_size=200
-) -> np.ndarray:
-    results = []
-    # get all text from the dataframe
-    raw_inputs = df["text"].tolist()
-
-    for i in range(0, len(raw_inputs), inference_api_batch_size):
-        inputs = raw_inputs[i : min(i + inference_api_batch_size, len(raw_inputs))]
-        payload = {"inputs": inputs, "options": {"use_cache": True}}
-
-        logger.debug(f"Requesting {len(inputs)} rows of data: ({i}/{len(raw_inputs)})")
-        output = {"error": "First attemp"}
-        while "error" in output:
-            # Retry
-            logger.debug(output)
-            sleep(0.5)
-            output = query(payload)
-
-        for i in output:
-            results.append(extract_scores(i))
-
-    logger.debug(f"Finished, got {len(results)} results")
-
-    return np.array(results)
 
 
 def classification_model_from_inference_api(
     model_name,
     labels,
     features,
-    query,
     model_type="text_classification",
     inference_api_batch_size=200,
 ):
     """
     Get a Giskard model from the HuggingFace inference API.
     """
-    if model_type == "text_classification":
-
-        def prediction(df: pd.DataFrame) -> np.ndarray:
-            return predict_from_text_classification_inference(
-                df, query, inference_api_batch_size
-            )
-
-    else:
+    if model_type != "text_classification":
         raise NotImplementedError(
             f"Not supported model type: {model_type}. Only text_classification models are supported for now."
         )
 
-    if prediction is None:
-        raise ValueError(
-            "The prediction function is None. Please check your model name and the inference API."
+    # Utility to query HF inference API
+    def query(payload):
+        hf_token = os.environ.get("HF_TOKEN")
+        if not hf_token:
+            raise ValueError(
+                "Missing Hugging Face access token. Please provide it in `HF_TOKEN` environment variable"
+            )
+
+        # Allow to customize the HF API endpoint
+        # See https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables#hfinferenceendpoint
+        hf_inference_api_endpoint = os.environ.get(
+            "HF_INFERENCE_ENDPOINT", default="https://api-inference.huggingface.co"
         )
+        url = f"{hf_inference_api_endpoint}/models/{model_name}"
+        headers = {"Authorization": f"Bearer {hf_token}"}
+        response = requests.post(url, headers=headers, json=payload)
+        if response.status_code != 200:
+            logger.debug(f"Request to inference API returns {response.status_code}")
+        try:
+            return response.json()
+        except Exception:
+            return {"error": response.content}
+
+    # Utitlity to extract scores
+    def extract_scores(data):
+        scores = []
+
+        if isinstance(data, dict):
+            # extract 'score' value if it exists
+            score = data.get("score")
+            if score is not None:
+                scores.append(score)
+
+            # Recursively process dictionary values
+            for value in data.values():
+                scores.extend(extract_scores(value))
+
+        elif isinstance(data, list):
+            # recursively process list elements
+            for element in data:
+                scores.extend(extract_scores(element))
+
+        return scores
+
+    # Text classification: limit the scope so that the model does not import giskard_cicd
+    def predict_from_text_classification_inference(df: pd.DataFrame) -> np.ndarray:
+        results = []
+        # get all text from the dataframe
+        raw_inputs = df["text"].tolist()
+
+        for i in range(0, len(raw_inputs), inference_api_batch_size):
+            inputs = raw_inputs[i : min(i + inference_api_batch_size, len(raw_inputs))]
+            payload = {"inputs": inputs, "options": {"use_cache": True}}
+
+            logger.debug(
+                f"Requesting {len(inputs)} rows of data: ({i}/{len(raw_inputs)})"
+            )
+            output = {"error": "First attemp"}
+            while "error" in output:
+                # Retry
+                logger.debug(output)
+                sleep(0.5)
+                output = query(payload)
+
+            for i in output:
+                results.append(extract_scores(i))
+
+        logger.debug(f"Finished, got {len(results)} results")
+
+        return np.array(results)
 
     return Model(
-        model=prediction,  # A prediction function that encapsulates all the data pre-processing steps and that
+        model=lambda df: predict_from_text_classification_inference(
+            df
+        ),  # A prediction function that encapsulates all the data pre-processing steps and that
         model_type="classification",  # Either regression, classification or text_generation.
         name=f"{model_name} HF inference API",  # Optional
         classification_labels=labels,  # Their order MUST be identical to the prediction_function's

--- a/giskard_cicd/loaders/huggingface_loader.py
+++ b/giskard_cicd/loaders/huggingface_loader.py
@@ -8,7 +8,7 @@ import datasets
 import giskard as gsk
 import huggingface_hub
 import pandas as pd
-import requests
+import os
 import torch
 from giskard import Dataset
 from giskard.models.base import BaseModel
@@ -210,25 +210,13 @@ class HuggingFaceLoader(BaseLoader):
                 raise ValueError(
                     "hf_token must be provided when using model_type='hf_inference_api'"
                 )
-
-            def _query_for_inference(payload):
-                url = f"https://api-inference.huggingface.co/models/{model_name}"
-                headers = {"Authorization": f"Bearer {hf_token}"}
-                response = requests.post(url, headers=headers, json=payload)
-                if response.status_code != 200:
-                    logger.debug(
-                        f"Request to inference API returns {response.status_code}"
-                    )
-                try:
-                    return response.json()
-                except Exception:
-                    return {"error": response.content}
+            # To be used later in inference API mmodel
+            os.environ.update([("HF_TOKEN", hf_token)])
 
             return classification_model_from_inference_api(
                 model_name,
                 labels,
                 features,
-                _query_for_inference,
                 inference_api_batch_size=inference_api_batch_size,
             )
 


### PR DESCRIPTION
Remove HF token.
Avoid importing `giskard_cicd` in inference API: reduce the scope so that pickle does not need import giskard only.