### PR TITLE
Keep auto aligned feature mapping only update keys

### DIFF
--- a/giskard_cicd/loaders/huggingface_loader.py
+++ b/giskard_cicd/loaders/huggingface_loader.py
@@ -78,14 +78,13 @@ class HuggingFaceLoader(BaseLoader):
 
         # Check that the dataset has the good feature names for the task.
         logger.debug("Retrieving feature mapping")
-        if manual_feature_mapping is None:
-            hf_model = self.load_model(model_id)
-            feature_mapping = self._get_feature_mapping(hf_model, hf_dataset)
-            logger.warn(
-                f'Feature mapping is not provided, using extracted "{feature_mapping}"'
-            )
-        else:
-            feature_mapping = manual_feature_mapping
+        hf_model = self.load_model(model_id)
+        feature_mapping = self._get_feature_mapping(hf_model, hf_dataset)
+        logger.warn(
+            f'Feature mapping is not provided, using extracted "{feature_mapping}"'
+        )
+        if manual_feature_mapping is not None:
+            feature_mapping.update(manual_feature_mapping)
 
         df = hf_dataset.to_pandas().rename(
             columns={v: k for k, v in feature_mapping.items()}

--- a/readme.md
+++ b/readme.md
@@ -104,12 +104,12 @@ Current implementation has two loaders:
 
   **Label Mapping**: map the dataset labels to model label **id**s. Use the labels2id or id2labels in model card to help you if needed. This should be **idx to key**. Example:
   ```
-  --label_mapping "{'0':'negative','1':'positive'}"
+  --label_mapping '{"0":"negative","1":"positive"}'
   ```
 
   **Feature Mapping**: map the feature labels directly from **key to key**.
   ```
-  --feature-mapping "{'sentence': 'text'}"
+  --feature-mapping '{"sentence": "text"}'
   ```
 
 This will launch a pipeline that will load the model and dataset from the HuggingFace hub, run the scan and generate a report in HTML format (for now).


### PR DESCRIPTION
When users give feature mappings, we still run the auto align and then update it with the keys user gave.

This PR also fixes the wrong json format in readme.