### PR TITLE
Update readme with correct mapping examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,12 +104,12 @@ Current implementation has two loaders:
 
   **Label Mapping**: map the dataset labels to model label **id**s. Use the labels2id or id2labels in model card to help you if needed. This should be **idx to key**. Example:
   ```
-  --label_mapping "{'0':'negative','1':'positive'}"
+  --label_mapping '{"0":"negative","1":"positive"}'
   ```
 
   **Feature Mapping**: map the feature labels directly from **key to key**.
   ```
-  --feature-mapping "{'sentence': 'text'}"
+  --feature-mapping '{"text": "sentence"}'
   ```
 
 This will launch a pipeline that will load the model and dataset from the HuggingFace hub, run the scan and generate a report in HTML format (for now).


### PR DESCRIPTION
The cli commands for mapping give in the readme was not in correct json format