### PR TITLE
[GSK-3235] Clean up HF tokens used in cicd

### DIFF
--- a/giskard_cicd/automation/utils.py
+++ b/giskard_cicd/automation/utils.py
@@ -13,8 +13,6 @@ def check_env_vars_and_login(hf_token=None, write_permission=False):
 
 
 def check_env_vars_and_login_for_dataset(hf_token=None, dataset_id=None):
-    if HF_WRITE_TOKEN is None and hf_token is None:
-        raise ValueError("HF_WRITE_TOKEN is not set")
 
     # check the leaderboard dataset exists
     if DATASET_ID is None and dataset_id is None:

--- a/giskard_cicd/automation/utils.py
+++ b/giskard_cicd/automation/utils.py
@@ -5,7 +5,14 @@ HF_WRITE_TOKEN = os.environ.get("HF_WRITE_TOKEN")
 DATASET_ID = os.environ.get("DATASET_ID")
 
 
-def check_env_vars_and_login(hf_token=None, dataset_id=None):
+def check_env_vars_and_login(hf_token=None, write_permission=False):
+    if HF_WRITE_TOKEN is None and hf_token is None:
+        raise ValueError("Neither hf_token nor HF_WRITE_TOKEN is set")
+
+    login(token=HF_WRITE_TOKEN or hf_token, write_permission=write_permission)
+
+
+def check_env_vars_and_login_for_dataset(hf_token=None, dataset_id=None):
     if HF_WRITE_TOKEN is None and hf_token is None:
         raise ValueError("HF_WRITE_TOKEN is not set")
 
@@ -13,7 +20,7 @@ def check_env_vars_and_login(hf_token=None, dataset_id=None):
     if DATASET_ID is None and dataset_id is None:
         raise ValueError("DATASET_ID is not set")
 
-    login(token=HF_WRITE_TOKEN or hf_token, write_permission=True)
+    check_env_vars_and_login(hf_token=hf_token, write_permission=True)
 
     logging.set_verbosity_debug()
 

--- a/giskard_cicd/cli.py
+++ b/giskard_cicd/cli.py
@@ -11,6 +11,7 @@ from giskard_cicd.automation import (
     create_discussion,
     init_dataset_commit_scheduler,
 )
+from giskard_cicd.automation.utils import check_env_vars_and_login
 from giskard_cicd.loaders import GithubLoader, HuggingFaceLoader
 from giskard_cicd.pipeline.runner import PipelineRunner
 from giskard_cicd.utils import giskard_hub_upload_helper
@@ -180,6 +181,10 @@ def main():
     )
     report = runner.run(**runner_kwargs)
 
+    if "HF_TOKEN" in os.environ:
+        # Unset HF_TOKEN, which was set before creation of HF inference API model
+        os.environ.pop("HF_TOKEN")
+
     persistent_url = None
     if args.persist_scan:
         try:
@@ -303,27 +308,30 @@ def main():
         rendered_report = report.to_html()
 
     if args.output_portal == "huggingface":
-        # Push to discussion
-        # FIXME: dataset config and dataset split might have been inferred
-        discussion = create_discussion(
-            args.discussion_repo,
-            args.model,
-            args.hf_token,
-            rendered_report,
-            args.dataset,
-            args.dataset_config,
-            args.dataset_split,
-            report,
-            test_suite_url,
-            persistent_url,
-        )
+        try:
+            # Login Hugging Face: use given token or HF_WRITE_TOKEN in env
+            check_env_vars_and_login(hf_token=args.hf_token)
 
-        if args.leaderboard_dataset:  # Commit to leaderboard dataset
-            scheduler = init_dataset_commit_scheduler(
-                hf_token=args.hf_token, dataset_id=args.leaderboard_dataset
+            # Push to discussion
+            # FIXME: dataset config and dataset split might have been inferred
+            discussion = create_discussion(
+                args.discussion_repo,
+                args.model,
+                args.hf_token,
+                rendered_report,
+                args.dataset,
+                args.dataset_config,
+                args.dataset_split,
+                report,
+                test_suite_url,
+                persistent_url,
             )
 
-            try:
+            if args.leaderboard_dataset:  # Commit to leaderboard dataset
+                scheduler = init_dataset_commit_scheduler(
+                    hf_token=args.hf_token, dataset_id=args.leaderboard_dataset
+                )
+
                 commit_to_dataset(
                     scheduler,
                     args.model,
@@ -333,8 +341,8 @@ def main():
                     discussion,
                     report,
                 )
-            except Exception as e:
-                logging.debug(f"Failed to commit to dataset: {e}")
+        except Exception as e:
+            logging.debug(f"Failed to submit to Hugging Face: {e}")
 
     if args.output:
         with open(args.output, "w") as f:

--- a/giskard_cicd/loaders/huggingface_loader.py
+++ b/giskard_cicd/loaders/huggingface_loader.py
@@ -240,7 +240,7 @@ class HuggingFaceLoader(BaseLoader):
                 raise ValueError(
                     "hf_token must be provided when using model_type='hf_inference_api'"
                 )
-            # To be used later in inference API mmodel
+            # To be used later in inference API model: avoid being pickled in model
             os.environ.update([("HF_TOKEN", hf_token)])
 
             return classification_model_from_inference_api(


### PR DESCRIPTION
HF_TOKEN env was set in HF inference API, to avoid pickling token into HF inference API model.
This gives a token when no `hf_token` provided.

- Unset it after scan.
- Try to use hf_token in args or HF_WRITE_TOKEN to submit scan report and dataset.